### PR TITLE
Hexabits 66 bug fix borrar tablero fichas

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -199,7 +199,6 @@ async def leave_lobby(leave_lobby: Leave_config, db: Session=Depends(get_db)):
             #Luego de abandonar la partida, le actualizo a los ws conectados la nueva lista de lobbies porque ahora tienen 1 jugador menos
             if jugador.es_anfitrion:
                 delete_players_lobby(partida, db)
-                print('hola')
                 await ws_manager.send_message_game_id(event.cancel_lobby, game_id=game_id)
             else:
                 delete_player(jugador, db)

--- a/src/main.py
+++ b/src/main.py
@@ -198,7 +198,7 @@ async def leave_lobby(leave_lobby: Leave_config, db: Session=Depends(get_db)):
         else:
             #Luego de abandonar la partida, le actualizo a los ws conectados la nueva lista de lobbies porque ahora tienen 1 jugador menos
             if jugador.es_anfitrion:
-                delete_players_partida(partida, db)
+                delete_players_lobby(partida, db)
                 print('hola')
                 await ws_manager.send_message_game_id(event.cancel_lobby, game_id=game_id)
             else:

--- a/src/repositories/board_repository.py
+++ b/src/repositories/board_repository.py
@@ -13,6 +13,16 @@ from src.models.fichas_cajon import FichaCajon
 from src.models.color_enum import Color
 from src.models.cartamovimiento import MovementCard, Move, CardStateMov
 
+def get_tablero(game_id: int, db: Session) -> Tablero:
+    smt = select(Tablero).where(Tablero.partida_id == game_id)
+    return db.execute(smt).scalar()
+
+
+def get_fichasCajon(tablero_id: int, db: Session) -> List[FichaCajon]:
+    smt = select(FichaCajon).where(FichaCajon.tablero_id == tablero_id)
+    return db.execute(smt).scalars().all()
+
+
 def get_fichas(game_id: int, db: Session) -> List[dict]:
 
     tablero = db.query(Tablero).filter(Tablero.partida_id == game_id).first()

--- a/src/repositories/player_repository.py
+++ b/src/repositories/player_repository.py
@@ -50,7 +50,7 @@ def asignar_turnos(game_id: int, db: Session) -> None:
         db.commit()
         db.refresh(jugador)
 
-def delete_players_partida(partida: Partida, db: Session) -> None:
+def delete_players_lobby(partida: Partida, db: Session) -> None:
     smt = select(Jugador).where(Jugador.partida_id == partida.id)
     jugadores = db.execute(smt).scalars().all()
     for jugador in jugadores:

--- a/src/repositories/player_repository.py
+++ b/src/repositories/player_repository.py
@@ -54,6 +54,9 @@ def delete_players_lobby(partida: Partida, db: Session) -> None:
     smt = select(Jugador).where(Jugador.partida_id == partida.id)
     jugadores = db.execute(smt).scalars().all()
     for jugador in jugadores:
+        if (jugador.es_anfitrion):
+            jugador.es_anfitrion = False
+            
         jugador.partida_id = None
     db.commit()
     delete_partida(partida, db)

--- a/tests/test_elim_jugador_lobby.py
+++ b/tests/test_elim_jugador_lobby.py
@@ -24,9 +24,9 @@ from sqlalchemy.exc import IntegrityError
 
 client = TestClient(app)
 
-@patch("src.main.delete_players_partida")
+@patch("src.main.delete_players_lobby")
 def test_endpoint_leave_lobby_anf (mock_delete_jugadores):
-    mock_delete_jugadores.side_effect = lambda partida, db: mock_delete_players_partida(partida.max_players, partida.partida_iniciada)
+    mock_delete_jugadores.side_effect = lambda partida, db: mock_delete_players_lobby(partida.max_players, partida.partida_iniciada)
     info_leave = {"id_user": 1, "game_id": 1}
     with patch("src.main.get_Jugador", return_value = Jugador(nombre="player_1", id=1, es_anfitrion=True, partida_id=1)) as mock_get_jugador:
         with patch("src.main.get_Partida", return_value = Partida(game_name="partida", max_players=4, id=1)) as mock_get_partida:

--- a/tests/test_helpers.py
+++ b/tests/test_helpers.py
@@ -1,19 +1,23 @@
 import pytest
 from sqlalchemy import create_engine
 from sqlalchemy.exc import SQLAlchemyError
-from sqlalchemy.orm import sessionmaker
+from sqlalchemy.orm import sessionmaker, Session
 from src.db import Base
 from src.models.partida import Partida
 from src.models.jugadores import Jugador
 from src.models.cartafigura import PictureCard, Picture, CardState
 from src.models.cartamovimiento import MovementCard, Move, CardStateMov
 from src.models.inputs_front import Partida_config
+from src.models.tablero import Tablero
+from src.models.color_enum import Color
+from src.models.fichas_cajon import FichaCajon
 from typing import List
 
 from src.repositories.cards_repository import get_cartasFigura_player, list_fig_cards, list_mov_cards, repartir_cartas_figuras
 from src.repositories.game_repository import  get_Partida
 from src.repositories.player_repository import add_partida
-from src.repositories.player_repository import delete_player, delete_players_partida, get_Jugador, player_in_partida
+from src.repositories.board_repository import get_fichasCajon, get_tablero
+from src.repositories.player_repository import delete_player, delete_players_lobby, get_Jugador, player_in_partida
 
 
 @pytest.fixture(scope='function')
@@ -54,14 +58,14 @@ def mock_add_partida(config: Partida_config) -> int:
         return id_game 
     
 
-def mock_delete_players_partida(max_players: int, empezada: bool):
+def mock_delete_players_lobby(max_players: int, empezada: bool):
     engine = create_engine('sqlite:///:memory:')
     Base.metadata.create_all(engine)
     SessionLocal = sessionmaker(bind=engine)
     with (SessionLocal() as test_db):
         db_prueba(max_players, empezada, test_db)
         partida = get_Partida(1, test_db)
-        delete_players_partida(partida, test_db)
+        delete_players_lobby(partida, test_db)
         assert player_in_partida(partida, test_db) == 0 
 
 
@@ -75,7 +79,13 @@ def mock_delete_player(max_players: int, empezada: bool):
         partida = get_Partida(jugador.partida_id, test_db)
         delete_player(jugador, test_db)
 
-        assert player_in_partida(partida, test_db) == (0 if partida.partida_iniciada and max_players == 1 else max_players - 1)
+        cant = player_in_partida(partida, test_db)
+        fichs = get_fichasCajon(1, test_db)
+        assert  cant == (0 if partida.partida_iniciada and max_players == 1 else max_players - 1)
+        
+        if (partida.partida_iniciada):
+            assert len(fichs) == (0 if max_players == 1 else 36)
+
         assert jugador.partida_id == None
 
 
@@ -94,17 +104,31 @@ def mock_repartir_figuras(max_players: int, figuras_list: List[int]):
             assert len([x for x in cartas if x.estado == CardState.mano]) == 3            
         
 
-def db_prueba(max_players: int, emepezada: bool, db: pytest.Session):
+def db_prueba(max_players: int, emepezada: bool, db: Session):
     try:
         partida = Partida(game_name="partida", max_players=max_players, partida_iniciada=emepezada)
         db.add(partida)
-        db.commit()
-        db.refresh(partida)
+        db.flush()
         for i in range(0, max_players):
             jugador = Jugador(nombre=f'player_{i}', turno=i+1)
             jugador.partida_id = partida.id
             db.add(jugador)
-        partida.jugador_en_turno = 1
+        
+        if (emepezada):
+            partida.jugador_en_turno = 1
+            tablero = Tablero()
+            tablero.partida_id = partida.id
+            db.add(tablero)
+            db.flush()
+
+            colores = [Color.ROJO]*9 + [Color.VERDE]*9 + [Color.AMARILLO]*9 + [Color.AZUL]*9
+            coordenadas = [(x, y) for x in range(1, 7) for y in range(1, 7)]
+            for coord in coordenadas:
+                x, y = coord
+                color = colores.pop()
+                ficha = FichaCajon(x_pos=x, y_pos=y, color=color, tablero_id=tablero.id)
+                db.add(ficha)
+
         db.commit()
     except SQLAlchemyError:
         db.rollback()
@@ -131,6 +155,7 @@ def mock_list_mov_cards (mov_cards: List[MovementCard]) -> List[int]:
         assert cards is not None
         return cards
 
+
 def mock_list_fig_cards (fig_cards: List[PictureCard]) -> List[int]:
     engine = create_engine('sqlite:///:memory:')
     Base.metadata.create_all(engine)
@@ -150,4 +175,3 @@ def mock_list_fig_cards (fig_cards: List[PictureCard]) -> List[int]:
 
         assert cards is not None
         return cards
-

--- a/tests/test_websockets.py
+++ b/tests/test_websockets.py
@@ -127,7 +127,7 @@ async def test_websocket_broadcast_games_leave(client):
 
         with patch("src.main.get_Jugador", return_value=mock_jugador) as mock_get_jugador, \
              patch("src.main.get_Partida", return_value=mock_partida) as mock_get_partida, \
-             patch("src.main.delete_players_partida") as mock_delete_players_partida:
+             patch("src.main.delete_players_lobby") as mock_delete_players_lobby:
             
             info_leave = {"id_user": 1, "game_id": 1}
 


### PR DESCRIPTION
La version anterior no borraba ni el tablero ni las fichas cajon de la partida cuando un jugador abandonaba una partida ya empezada. Luego si abandonabas la partida cómo owner y te unias a otra partida podías borrarla abandonando, por más de no ser owner de la segunda partida.