### PR TITLE
FIX: sanitizacion de inputs

### DIFF
--- a/src/main.py
+++ b/src/main.py
@@ -626,6 +626,9 @@ async def use_fig_card(figureData: FigureData, db: Session = Depends(get_db)):
         figura: [{x_pos: int, y_pos: int}]}
     """
     try:
+        if (len(figureData.figura)==0):
+            raise HTTPException(status_code= status.HTTP_400_BAD_REQUEST, detail="Figura invalida")
+        
         jugador = get_Jugador(figureData.player_id, db)
         pictureCard = get_CartaFigura(figureData.id_fig_card, db)
         


### PR DESCRIPTION
BUG: Si el frontend te manda una lista vacia como campos del endpoint use_fig_card, al ser una lista, por mas que este vacia esta intenta acceder a los campos de coordenadas que no tiene, produciendo un error que reinicia el backend.
Solucion: Enviar un error 400 si la lista de coords que viene del front es vacia (len == 0)