### PR TITLE
BUGFIX: No listar mis partidas que ya tienen ganador

### DIFF
--- a/src/repositories/game_repository.py
+++ b/src/repositories/game_repository.py
@@ -121,7 +121,7 @@ def list_lobbies(username: str,db: Session) -> List[dict]:
         #Calculo la cantidad de jugadores actuales en partida
         current_players = db.query(Jugador).filter(Jugador.partida_id == lobby.id).count()
         if current_players == 0 or (lobby.partida_iniciada and not name_already_in_game)\
-                                or (name_already_in_game and not lobby.partida_iniciada):
+            or lobby.winner_id!=None or (name_already_in_game and not lobby.partida_iniciada):
             continue
         
         if (lobby.partida_iniciada):


### PR DESCRIPTION
BUG: Si se gana una partida al quedarse sin cartas un jugador, otro jugador podria irse a home sin tocar el boton abandonar y ver en sus partidas activas la partida que ya tiene ganador, pero que no borro el lobby porque sigue con jugadores adentro.

La solucion a esto, es no enviar en la lista de partidas mis partidas activas que ya tengan un ganador establecido en el campo Partida.winner_id