### PR TITLE
Hexabits 159 fix figuras 3x3

### DIFF
--- a/src/game_helpers.py
+++ b/src/game_helpers.py
@@ -268,21 +268,11 @@ def is_valid_picture_card(pictureCard: PictureCard, coords: List[Coords]) -> boo
         matriz[x-1][y-1] = 1
     
     submatriz = matriz[min_x-1 : min_x-1 + filas, min_y-1 : min_y-1 + columnas]
-    print("hola submatriz b")
-    print(type(submatriz))
-    submatriz = np.array(submatriz)
-    print(type(submatriz))
-    print("chau sub b")
 
     figure_rotations = generar_rotaciones(figure)
 
     for fig in figure_rotations:
-        print("hola fig b")
-        print(type(fig))
         fig = np.array(fig)
-        print(type(fig))
-        print("chau fig b")
-        print(fig)
         if fig.shape == submatriz.shape:
             match = (fig == -1) | (submatriz == fig)
             if np.all(match):

--- a/src/game_helpers.py
+++ b/src/game_helpers.py
@@ -145,13 +145,14 @@ def detect_patterns(matriz, patterns) -> List[List[Tuple[int, int]]]:
             for j in range(columnas - p_columnas + 1):
                 # Extraer la submatriz de la ventana deslizante
                 submatriz = matriz[i:i + p_filas, j:j + p_columnas]
-                
+
                 # Compara la submatriz con el patrón considerando -1 como comodín
-                match = (patron == -1) | (submatriz == patron)
-                if np.all(match):
-                    # Si coinciden, guardar las coordenadas
-                    coords = [(i + x, j + y) for x in range(p_filas) for y in range(p_columnas) if patron[x, y] == 1]
-                    figuras_detectadas.append(coords)
+                if submatriz.shape == patron.shape:
+                    match = (patron == -1) | (submatriz == patron)
+                    if np.all(match):
+                        # Si coinciden, guardar las coordenadas
+                        coords = [(i + x, j + y) for x in range(p_filas) for y in range(p_columnas) if patron[x, y] == 1]
+                        figuras_detectadas.append(coords)
 
     return figuras_detectadas
 
@@ -267,14 +268,25 @@ def is_valid_picture_card(pictureCard: PictureCard, coords: List[Coords]) -> boo
         matriz[x-1][y-1] = 1
     
     submatriz = matriz[min_x-1 : min_x-1 + filas, min_y-1 : min_y-1 + columnas]
-    
+    print("hola submatriz b")
+    print(type(submatriz))
+    submatriz = np.array(submatriz)
+    print(type(submatriz))
+    print("chau sub b")
+
     figure_rotations = generar_rotaciones(figure)
 
     for fig in figure_rotations:
-
-        match = (fig == -1) | (submatriz == fig)
-        if np.all(match):
-            return True
+        print("hola fig b")
+        print(type(fig))
+        fig = np.array(fig)
+        print(type(fig))
+        print("chau fig b")
+        print(fig)
+        if fig.shape == submatriz.shape:
+            match = (fig == -1) | (submatriz == fig)
+            if np.all(match):
+                return True
         
     return False
 

--- a/src/game_helpers.py
+++ b/src/game_helpers.py
@@ -146,8 +146,9 @@ def detect_patterns(matriz, patterns) -> List[List[Tuple[int, int]]]:
                 # Extraer la submatriz de la ventana deslizante
                 submatriz = matriz[i:i + p_filas, j:j + p_columnas]
                 
-                # Comparar submatriz con el patrón
-                if np.array_equal(submatriz, patron):
+                # Compara la submatriz con el patrón considerando -1 como comodín
+                match = (patron == -1) | (submatriz == patron)
+                if np.all(match):
                     # Si coinciden, guardar las coordenadas
                     coords = [(i + x, j + y) for x in range(p_filas) for y in range(p_columnas) if patron[x, y] == 1]
                     figuras_detectadas.append(coords)
@@ -270,7 +271,9 @@ def is_valid_picture_card(pictureCard: PictureCard, coords: List[Coords]) -> boo
     figure_rotations = generar_rotaciones(figure)
 
     for fig in figure_rotations:
-        if np.array_equal(fig, submatriz):
+
+        match = (fig == -1) | (submatriz == fig)
+        if np.all(match):
             return True
         
     return False

--- a/src/models/patrones_figuras_matriz.py
+++ b/src/models/patrones_figuras_matriz.py
@@ -48,7 +48,7 @@ def pictureCardsFigures() -> list[np.ndarray]:
     figures_list.append(fig03)
 
     fig04 = [
-        [1, 0, 0],
+        [1, 0, -1],
         [1, 1, 0],
         [0, 1, 1]
     ]
@@ -60,7 +60,7 @@ def pictureCardsFigures() -> list[np.ndarray]:
     figures_list.append(fig05)
 
     fig06 = [
-        [1, 0, 0],
+        [1, 0, -1], #el -1 es un comodin
         [1, 0, 0],
         [1, 1, 1]
     ]


### PR DESCRIPTION
Los patrones 3x3 al tener las esquinas en 0 no matchean con figuras que si deberian ser validas.

Solucion: Cambiar el 0 por un -1 y usarlo como comodin en el np.match(all), usando el -1 dentro de un or en el match